### PR TITLE
disable auto-exposure on Firefox WebGL2 to unlock framerate

### DIFF
--- a/src/replay-viewer/ReplayViewerOverlay.vue
+++ b/src/replay-viewer/ReplayViewerOverlay.vue
@@ -66,6 +66,7 @@ const showStats = ref(false);
 const showSettings = ref(false);
 const showInfo = ref(true);
 const renderSettings = ref<RenderSettings>({ ...DEFAULT_RENDER_SETTINGS });
+const autoExposureSupported = ref(true);
 
 function onSettingsChanged(s: RenderSettings) {
   renderSettings.value = s;
@@ -145,6 +146,7 @@ async function initViewer() {
   if (!canvas.value) throw new Error("Canvas not mounted");
   const { NoclipRenderer } = await import("./noclipRenderer");
   renderer = new NoclipRenderer(canvas.value);
+  autoExposureSupported.value = renderer.isAutoExposureSupported();
 
   stepLabel.value = "Parsing map...";
   await waitForNextPaint();
@@ -302,6 +304,7 @@ function close() {
       v-if="!isLoading && !errorMessage"
       :show="showSettings"
       :model-value="renderSettings"
+      :auto-exposure-supported="autoExposureSupported"
       @update:model-value="onSettingsChanged"
       @close="showSettings = false"
     />

--- a/src/replay-viewer/ViewerSettings.vue
+++ b/src/replay-viewer/ViewerSettings.vue
@@ -2,10 +2,13 @@
 import { ref, watch } from 'vue'
 import type { RenderSettings } from './renderSettings'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   modelValue: RenderSettings
   show: boolean
-}>()
+  autoExposureSupported?: boolean
+}>(), {
+  autoExposureSupported: true,
+})
 
 const emit = defineEmits<{
   'update:modelValue': [RenderSettings]
@@ -50,13 +53,21 @@ function commit() {
           class="accent-green-700"
         />
       </label>
-      <label class="flex items-center justify-between cursor-pointer">
-        <span class="text-gray-300">Auto-exposure</span>
+      <label
+        class="flex items-center justify-between"
+        :class="props.autoExposureSupported ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'"
+        :title="props.autoExposureSupported ? '' : 'Auto-exposure is disabled in this browser because gl.getQueryParameter stalls the JS thread on Firefox.'"
+      >
+        <span class="text-gray-300">
+          Auto-exposure
+          <span v-if="!props.autoExposureSupported" class="text-xs text-gray-500">(unsupported)</span>
+        </span>
         <input
           type="checkbox"
           v-model="local.autoExposure"
+          :disabled="!props.autoExposureSupported"
           @change="commit"
-          class="accent-green-700"
+          class="accent-green-700 disabled:cursor-not-allowed"
         />
       </label>
       <label class="flex items-center justify-between cursor-pointer">

--- a/src/replay-viewer/noclipRenderer.ts
+++ b/src/replay-viewer/noclipRenderer.ts
@@ -174,7 +174,11 @@ export class NoclipRenderer {
         // antialias: false — noclip renders to its own offscreen target and
         // blits the resolve to the default framebuffer; a multisampled
         // default FB makes that blit invalid.
-        const gl = canvas.getContext("webgl2", { antialias: false });
+        // powerPreference: "high-performance" nudges Safari/iOS off the
+        // low-power GPU path; on ProMotion iPhones that path is also where the
+        // 60Hz rAF cap tends to stick. Won't help if iOS Low Power Mode is on
+        // -- Apple forces 60Hz unconditionally there.
+        const gl = canvas.getContext("webgl2", { antialias: false, powerPreference: "high-performance" });
         if (!gl) throw new Error("WebGL2 not supported");
         this.gl = gl;
 

--- a/src/replay-viewer/noclipRenderer.ts
+++ b/src/replay-viewer/noclipRenderer.ts
@@ -146,16 +146,26 @@ export class NoclipRenderer {
         this.applySettingsToContext();
     }
 
+    public isAutoExposureSupported(): boolean {
+        // The auto-exposure path on WebGL2 polls occlusion query results every
+        // frame. Firefox makes gl.getQueryParameter a synchronous GPU-process
+        // round-trip, which stalls the JS thread (~75% of frame time in
+        // testing) and tanks FPS. The WebGL2 backend already exposes this as
+        // occlusionQueriesRecommended; honor it.
+        return this.device.queryLimits().occlusionQueriesRecommended;
+    }
+
     private applySettingsToContext(): void {
         if (this.renderContext === null) return;
+        const autoExposure = this.settings.autoExposure && this.isAutoExposureSupported();
         this.renderContext.enableBloom = this.settings.bloom;
-        this.renderContext.enableAutoExposure = this.settings.autoExposure;
+        this.renderContext.enableAutoExposure = autoExposure;
         this.renderContext.enableFog = !this.settings.disableFog;
 
         if (this.settings.fullbright) {
             this.renderContext.enableAutoExposure = false;
             this.renderContext.toneMapParams.toneMapScale = 4.0;
-        } else if (!this.settings.autoExposure) {
+        } else if (!autoExposure) {
             this.renderContext.toneMapParams.toneMapScale = 1.0;
         }
     }


### PR DESCRIPTION
The luminance histogram path used for auto-exposure on WebGL2 issues hundreds of occlusion queries per frame and then polls
gl.getQueryParameter to read them back. On Firefox that call is a synchronous IPC round-trip to the GPU process, so the JS thread blocks waiting for the result - a Firefox profile h_k on a simple, water-less map showed ~75% of frame time stalled inqueryPoolResultOcclusion / WebGL2RenderingContext.getQueryParameter, and 30 FPS rising to a locked 165 FPS the moment auto-exposure was turned off.